### PR TITLE
Add options param to fetch request

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -37,6 +37,12 @@ export default class App extends Component<Props> {
       apkVersionUrl:
         "https://raw.githubusercontent.com/mikehardy/react-native-update-apk/master/example/test-version.json",
 
+      //apkVersionOptions is optional, you should use it if you need to pass options to fetch request
+      apkVersionOptions: {
+        method:'GET',
+        headers: {}
+      },
+      
       // The name of this 'fileProviderAuthority' is defined in AndroidManifest.xml. THEY MUST MATCH.
       // By default other modules like rn-fetch-blob define one (conveniently named the same as below)
       // but if you don't match the names you will get an odd-looking XML exception:

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ export class UpdateAPK {
     this.options = options;
   }
 
-  get = (url, success, error) => {
-    fetch(url)
+  get = (url, success, error, options = {}) => {
+    fetch(url, options)
       .then(response => response.json())
       .then(json => {
         success && success(json);
@@ -33,7 +33,8 @@ export class UpdateAPK {
     this.get(
       this.options.apkVersionUrl,
       this.getApkVersionSuccess.bind(this),
-      this.getVersionError.bind(this)
+      this.getVersionError.bind(this),
+      this.options.apkVersionOptions
     );
   };
 


### PR DESCRIPTION
Add apkVersionOptions to UpdateAPK options.
apkVersionOptions should be used if you need to pass options to fetch request.
Method get calls fetch with url and options now.