### PR TITLE
Added headers param to download the new APK file.

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -43,6 +43,10 @@ export default class App extends Component<Props> {
         headers: {}
       },
       
+      //apkHeaders is optional and it is an object of headers to be passed to the server
+      //You should use it if you need to pass headers besides the url (apkUrl from test-version.json) to download the new APK
+      apkHeaders: {},
+
       // The name of this 'fileProviderAuthority' is defined in AndroidManifest.xml. THEY MUST MATCH.
       // By default other modules like rn-fetch-blob define one (conveniently named the same as below)
       // but if you don't match the names you will get an odd-looking XML exception:

--- a/example/App.js
+++ b/example/App.js
@@ -43,9 +43,13 @@ export default class App extends Component<Props> {
         headers: {}
       },
       
-      //apkHeaders is optional and it is an object of headers to be passed to the server
-      //You should use it if you need to pass headers besides the url (apkUrl from test-version.json) to download the new APK
-      apkHeaders: {},
+      //apkOptions is optional
+      //Complements or replaces the DownloadFileOptions (from react-native-fs) to download the new APK
+      //By default the following options are already set: fromUrl, toFile, begin, progress, background and progressDivider
+      //You should use it if you need to pass additional information (for example: headers) to download the new APK
+      apkOptions: {
+        headers: {}
+      },
 
       // The name of this 'fileProviderAuthority' is defined in AndroidManifest.xml. THEY MUST MATCH.
       // By default other modules like rn-fetch-blob define one (conveniently named the same as below)

--- a/index.js
+++ b/index.js
@@ -84,9 +84,12 @@ export class UpdateAPK {
     // You might check {totalSpace, freeSpace} = await RNFS.getFSInfo() to make sure there is room
     const downloadDestPath = `${RNFS.CachesDirectoryPath}/NewApp.apk`;
 
+    let headers = this.options.apkHeaders ? this.options.apkHeaders : {};
+
     const ret = RNFS.downloadFile({
       fromUrl: remote.apkUrl,
       toFile: downloadDestPath,
+      headers: headers,
       begin,
       progress,
       background: true,

--- a/index.js
+++ b/index.js
@@ -84,22 +84,29 @@ export class UpdateAPK {
     // You might check {totalSpace, freeSpace} = await RNFS.getFSInfo() to make sure there is room
     const downloadDestPath = `${RNFS.CachesDirectoryPath}/NewApp.apk`;
 
-    let headers = this.options.apkHeaders ? this.options.apkHeaders : {};
+    let options = this.options.apkOptions ? this.options.apkOptions : {};
 
-    const ret = RNFS.downloadFile({
-      fromUrl: remote.apkUrl,
-      toFile: downloadDestPath,
-      headers: headers,
-      begin,
-      progress,
-      background: true,
-      progressDivider
-    });
+    const ret = RNFS.downloadFile(
+      Object.assign(
+        {
+          fromUrl: remote.apkUrl,
+          toFile: downloadDestPath,
+          begin,
+          progress,
+          background: true,
+          progressDivider
+        },
+        options
+      )
+    );
 
     jobId = ret.jobId;
 
     ret.promise
       .then(res => {
+        if (res['statusCode'] >= 400 && res['statusCode'] <= 599){
+          throw "Failed to Download APK. Server returned with " + res['statusCode'] + " statusCode";
+        }
         console.log("RNUpdateAPK::downloadApk - downloadApkEnd");
         this.options.downloadApkEnd && this.options.downloadApkEnd();
         RNUpdateAPK.getApkInfo(downloadDestPath)


### PR DESCRIPTION
Added apkHeaders to UpdateAPK options. This param is optional and it is an object of headers to be passed to the server to download the new APK. 

I tested this sending the apkHeaders (authorization) when the user needed to be autenticated and without the apkHeaders when the headers were not necessary. 