### PR TITLE
fix(android): android gradle plugin 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "net.mikehardy.rnupdateapk"
+    }
+
     compileSdkVersion safeExtGet('compileSdkVersion', 30)
 
     defaultConfig {


### PR DESCRIPTION

Backwards-compatible AGP8+ compatibility for use in react-native 0.73+